### PR TITLE
Xhtml support + speed bump

### DIFF
--- a/django_inlinify/inlinify.py
+++ b/django_inlinify/inlinify.py
@@ -60,6 +60,13 @@ class Inlinify(object):
 
         original_styles = {}
         for __, selector, new_style in rules:
+
+            # this check will avoid having to create a CSSSelector to then discover than there
+            # is not any matching element in the document. Each selector can take up to 1.5ms, so
+            # this is a huge time saver
+            if selector not in stripped:
+                continue
+
             sel = CSSSelector(selector)
             for item in sel(page):
                 current_style = item.attrib.get('style', '')
@@ -83,6 +90,7 @@ class Inlinify(object):
         """Processes the provided external CSS files, if any
         """
         rules = []
+        head = CSSSelector('head')(page)
         for index, css_body in enumerate(self.css_source):
             these_rules, these_leftover = self.css_parser.parse(css_body, index)
             rules.extend(these_rules)
@@ -90,7 +98,6 @@ class Inlinify(object):
                 style = etree.Element('style')
                 style.attrib['type'] = 'text/css'
                 style.text = these_leftover
-                head = CSSSelector('head')(page)
                 if head:
                     head[0].append(style)
         return rules

--- a/django_inlinify/inlinify.py
+++ b/django_inlinify/inlinify.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 import operator
+import re
 import sys
 if sys.version_info >= (3, ):  # pragma: no cover
     # As in, Python 3
@@ -16,6 +17,10 @@ from django_inlinify.css_tools import CSSLoader, CSSParser
 __all__ = ['Inlinify']
 
 
+SINGLE_SELECTOR_REGEX = re.compile('^[\w\-.#]+$')
+CDATA_REGEX = re.compile(r'<!\[CDATA\[(.*?)\]\]\>', re.DOTALL)
+
+
 class Inlinify(object):
 
     def __init__(self,
@@ -23,12 +28,17 @@ class Inlinify(object):
                  base_url=None,
                  preserve_internal_links=False,
                  preserve_inline_attachments=True,
+                 method='html',
                  **kwargs):
 
         # attributes required by the URL parser
         self.base_url = base_url
         self.preserve_internal_links = preserve_internal_links
         self.preserve_inline_attachments = preserve_inline_attachments
+        self.method = method
+
+        if self.method not in ('html', 'xml'):
+            raise ValueError('{} is not supported as a method'.format(method))
 
         # initialize parser and loader
         self.css_parser = CSSParser(**kwargs)
@@ -37,7 +47,12 @@ class Inlinify(object):
     def transform(self, html, pretty_print=True, **kwargs):
         """Transform CSS into inline styles and inject them in the provided html
         """
-        parser = etree.HTMLParser()
+        parser = None
+        if self.method == 'html':
+            parser = etree.HTMLParser()
+        elif self.method == 'xml':
+            parser = etree.XMLParser(ns_clean=False, resolve_entities=False)
+
         stripped = html.strip()
         tree = etree.fromstring(stripped, parser).getroottree()
         page = tree.getroot()
@@ -64,7 +79,7 @@ class Inlinify(object):
             # this check will avoid having to create a CSSSelector to then discover than there
             # is not any matching element in the document. Each selector can take up to 1.5ms, so
             # this is a huge time saver
-            if selector not in stripped:
+            if SINGLE_SELECTOR_REGEX.match(selector) and selector not in stripped:
                 continue
 
             sel = CSSSelector(selector)
@@ -81,10 +96,17 @@ class Inlinify(object):
         self._transform_urls(page)
 
         # set some default options
-        kwargs.setdefault('method', 'html')
+        kwargs.setdefault('method', self.method)
         kwargs.setdefault('pretty_print', pretty_print)
         kwargs.setdefault('encoding', 'utf-8')
-        return etree.tostring(root, **kwargs).decode(kwargs['encoding'])
+
+        html = etree.tostring(root, **kwargs).decode(kwargs['encoding'])
+
+        # need to replace the "<![CDATA" style comments with "/*<![CDATA" comments to be valid XHTML
+        if self.method == 'xml':
+            html = CDATA_REGEX.sub(lambda m: '/*<![CDATA[*/%s/*]]>*/' % m.group(1), html)
+
+        return html
 
     def _process_external_files(self, page):
         """Processes the provided external CSS files, if any
@@ -97,7 +119,10 @@ class Inlinify(object):
             if these_leftover:
                 style = etree.Element('style')
                 style.attrib['type'] = 'text/css'
-                style.text = these_leftover
+                if self.method == 'html':
+                    style.text = these_leftover
+                elif self.method == 'xml':
+                    style.text = etree.CDATA(these_leftover)
                 if head:
                     head[0].append(style)
         return rules

--- a/django_inlinify/tests/css/test_xml.css
+++ b/django_inlinify/tests/css/test_xml.css
@@ -1,0 +1,5 @@
+@media all and (max-width: 400px) {
+    h1 {
+        color: blue;
+    }
+}

--- a/django_inlinify/tests/html/test_xml.html
+++ b/django_inlinify/tests/html/test_xml.html
@@ -1,0 +1,10 @@
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    <html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Title</title>
+    </head>
+    <body>
+    <h1>Hi!</h1>
+    </body>
+    </html>

--- a/django_inlinify/tests/html/test_xml_expected.html
+++ b/django_inlinify/tests/html/test_xml_expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Title</title>
+    <style type="text/css">/*<![CDATA[*/@media all and (max-width: 400px) {
+            h1 {
+                color: blue !important
+            }
+        }/*]]>*/</style>
+</head>
+<body>
+<h1>Hi!</h1>
+</body>
+</html>

--- a/django_inlinify/tests/test_inlinify.py
+++ b/django_inlinify/tests/test_inlinify.py
@@ -245,7 +245,6 @@ class Tests(unittest.TestCase):
         """
         If the HTML contains a doctype it should not be removed.
         """
-
         html = read_html_file('test_doctype.html')
         compare_html(html, Inlinify().transform(html))
 
@@ -278,3 +277,15 @@ class Tests(unittest.TestCase):
         html = read_html_file('test_style_attribute_specificity_input.html')
         expected_output = read_html_file('test_style_attribute_specificity_expected.html')
         compare_html(expected_output, Inlinify().transform(html))
+
+    def test_xml(self):
+        """
+        Styles already present in an elements 'style' tag should win over all else.
+        """
+        html = read_html_file('test_xml.html')
+        expected_output = read_html_file('test_xml_expected.html')
+        css_style_path = css_path('test_xml.css')
+        print Inlinify(method='xml',
+                                               css_files=[css_style_path]).transform(html)
+        compare_html(expected_output, Inlinify(method='xml',
+                                               css_files=[css_style_path]).transform(html))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-inlinify',
-    version='0.0.13',
+    version='0.0.14',
     description="In-lines CSS into HTML and leverages Django's caching framework.",
     long_description="In-lines CSS into HTML and leverages Django's caching framework.",
     keywords='html lxml email mail style',


### PR DESCRIPTION
This PR includes two changes:
 - adds support for XHTML @jonbretman 
 - when inlining CSS, checks if the selector is in the HTML file before trying to look it up using CSSSelector. This saves us ~1.5 ms for each selector that does not appear in the html file