### PR TITLE
Python 3.4 compatibility and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,18 @@ DJANGO_INLINIFY_CSSLOADER_CACHE_KEY_TTL
 Running tests
 ----
 
+The best way to run tests is to do it using `tox` so they run in different environments, ensuring compatiblity with
+different python versions
+
 ```python
-DJANGO_SETTINGS_MODULE="django_inlinify.test_settings" python setup.py test
+# install tox if you haven't already
+pip install tox
+
+# run it
+tox
 ```
 
 Version
 ----
 
-0.0.13
+0.0.16

--- a/django_inlinify/css_tools.py
+++ b/django_inlinify/css_tools.py
@@ -1,15 +1,21 @@
-import re
-import logging
-import requests
-import cssutils
-from django.core.cache import get_cache, InvalidCacheBackendError
-from django.conf import settings
-from django_inlinify import defaults
-from StringIO import StringIO
+from __future__ import absolute_import, unicode_literals
+
 from contextlib import closing
 from hashlib import md5
+import logging
+import re
 
-log = logging.getLogger('django_inlinify.css_loader')
+import cssutils
+import requests
+
+from django.core.cache import get_cache, InvalidCacheBackendError
+from django.conf import settings
+
+from django_inlinify import defaults
+
+from six import StringIO
+
+log = logging.getLogger(__name__)
 
 DJANGO_INLINIFY_DEFAULT_CACHE_BACKEND_NAME = getattr(
     settings,
@@ -145,7 +151,7 @@ class CSSParser(object):
         self.include_star_selectors = kwargs.get('include_star_selectors', False)
 
     def _get_cache_key(self, css_body, index):
-        h = md5(str(css_body)).hexdigest()
+        h = md5(str(css_body).encode('utf-8')).hexdigest()
         return '%s_contents_%s_%s' % (self.DJANGO_INLINIFY_CSSPARSER_CACHE_KEY_PREFIX, h, index)
 
     def _get_cached_css(self, css_body, index):
@@ -266,7 +272,8 @@ class CSSParser(object):
         old_style_dict = self._css_string_to_dict(old_style)
         style_dict = self._css_string_to_dict(new_style)
         old_style_dict.update(style_dict)
-        return '; '.join(['%s:%s' % (k, v) for k, v in sorted(old_style_dict.iteritems())])
+
+        return '; '.join(['%s:%s' % (k, v) for k, v in sorted(old_style_dict.items())])
 
     def _unbalanced(self, text):
         """

--- a/django_inlinify/inlinify.py
+++ b/django_inlinify/inlinify.py
@@ -1,18 +1,15 @@
 from __future__ import absolute_import, unicode_literals
+
 import operator
 import re
-import sys
-if sys.version_info >= (3, ):  # pragma: no cover
-    # As in, Python 3
-    from urllib.parse import urljoin
-    STR_TYPE = str
-else:  # Python 2
-    from urlparse import urljoin
-    STR_TYPE = basestring
+
+from django_inlinify.css_tools import CSSLoader, CSSParser
+
+from six.moves.urllib.parse import urljoin
 
 from lxml import etree
 from lxml.cssselect import CSSSelector
-from django_inlinify.css_tools import CSSLoader, CSSParser
+
 
 __all__ = ['Inlinify']
 
@@ -154,7 +151,7 @@ class Inlinify(object):
     def _reapply_original_inline_styles(self, original):
         """Re-applies all the initial inline styles
         """
-        for item, inline_style in original.iteritems():
+        for item, inline_style in original.items():
             if not inline_style:
                 continue
             self._update_element_style(item, item.attrib.get('style', ''), inline_style)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-inlinify',
-    version='0.0.15',
+    version='0.0.16',
     description="In-lines CSS into HTML and leverages Django's caching framework.",
     long_description="In-lines CSS into HTML and leverages Django's caching framework.",
     keywords='html lxml email mail style',
@@ -18,14 +18,14 @@ setup(
     ],
     packages=find_packages(),
     include_package_data=True,
-    test_suite='nose.collector',
-    tests_require=['nose'],
     zip_safe=False,
     install_requires=[
+        'six',
         'lxml',
         'cssselect',
         'cssutils',
         'django>=1.5',
         'requests',
+        'tox'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = flake8,py27,py33,py34
+
+[testenv]
+setenv=
+    DJANGO_SETTINGS_MODULE=django_inlinify.test_settings
+deps=pytest
+commands= py.test


### PR DESCRIPTION
- compatible with python 3.4
- using py.test to run tests
- tox to ensure compatibility across python versions

I also updated the tests so no file handlers are left open in every test.
