### PR TITLE
Update to handle Django 1.9 caching deprecations

### DIFF
--- a/django_inlinify/css_tools.py
+++ b/django_inlinify/css_tools.py
@@ -8,7 +8,7 @@ import re
 import cssutils
 import requests
 
-from django.core.cache import get_cache, InvalidCacheBackendError
+from django.core.cache import caches, InvalidCacheBackendError
 from django.conf import settings
 
 from django_inlinify import defaults
@@ -45,13 +45,13 @@ def load_cache(cache_name):
         cache object
     """
     if not cache_name:
-        return get_cache(DJANGO_INLINIFY_DEFAULT_CACHE_BACKEND_NAME)
+        return caches[DJANGO_INLINIFY_DEFAULT_CACHE_BACKEND_NAME]
     try:
-        cache = get_cache(cache_name)
+        cache = caches[cache_name]
     except InvalidCacheBackendError:
         log.error('The cache you specified (%s) is not defined in settings. Falling back to '
                   'the default one (%s)', cache_name, DJANGO_INLINIFY_DEFAULT_CACHE_BACKEND_NAME)
-        cache = get_cache(DJANGO_INLINIFY_DEFAULT_CACHE_BACKEND_NAME)
+        cache = caches[DJANGO_INLINIFY_DEFAULT_CACHE_BACKEND_NAME]
     return cache
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-inlinify',
-    version='0.0.16',
+    version='0.0.17',
     description="In-lines CSS into HTML and leverages Django's caching framework.",
     long_description="In-lines CSS into HTML and leverages Django's caching framework.",
     keywords='html lxml email mail style',
@@ -24,7 +24,7 @@ setup(
         'lxml',
         'cssselect',
         'cssutils',
-        'django>=1.5',
+        'django>=1.7',
         'requests',
         'tox'
     ]


### PR DESCRIPTION
Because of these deprecations: https://docs.djangoproject.com/en/1.8/topics/cache/#django.core.cache.caches

Updating to handle Django 1.9 support.
